### PR TITLE
Changed SwordToken formatting to sword:<uuid> + changed name of filePidToLocalPath field.

### DIFF
--- a/src/main/openapi/dd-vault-catalog-api.yml
+++ b/src/main/openapi/dd-vault-catalog-api.yml
@@ -185,11 +185,11 @@ components:
     SwordToken:
       type: string
       x-field-extra-annotation: "@nl.knaw.dans.validation.SwordToken"
-    
+
     BagId:
       type: string
       x-field-extra-annotation: "@nl.knaw.dans.validation.UrnUuid"
-    
+
     Dataset:
       type: object
       required:
@@ -210,7 +210,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/VersionExport'
-    
+
     VersionExport:
       type: object
       required:

--- a/src/main/openapi/dd-vault-catalog-api.yml
+++ b/src/main/openapi/dd-vault-catalog-api.yml
@@ -60,7 +60,7 @@ paths:
           required: false
           schema:
             type: string
-            enum: [application/json, text/html]
+            enum: [ application/json, text/html ]
             default: application/json
       responses:
         200:
@@ -104,7 +104,7 @@ paths:
           in: query
           required: true
           schema:
-            type: string
+            $ref: '#/components/schemas/SwordToken'
       responses:
         200:
           description: a description of the dataset
@@ -126,7 +126,7 @@ paths:
           in: path
           required: true
           schema:
-            type: int
+            type: integer
       responses:
         200:
           description: a description of the version export
@@ -168,7 +168,7 @@ paths:
           in: path
           required: true
           schema:
-            type: string
+            $ref: '#/components/schemas/BagId'
       responses:
         200:
           description: a description of the dataset version export
@@ -182,6 +182,14 @@ paths:
 components:
 
   schemas:
+    SwordToken:
+      type: string
+      x-field-extra-annotation: "@nl.knaw.dans.validation.SwordToken"
+    
+    BagId:
+      type: string
+      x-field-extra-annotation: "@nl.knaw.dans.validation.UrnUuid"
+    
     Dataset:
       type: object
       required:
@@ -195,15 +203,14 @@ components:
         dataversePid:
           type: string
         swordToken:
-          type: string
-          x-field-extra-annotation: "@nl.knaw.dans.validation.UrnUuid"
+          $ref: '#/components/schemas/SwordToken'
         dataSupplier:
           type: string
         versionExports:
           type: array
           items:
             $ref: '#/components/schemas/VersionExport'
-
+    
     VersionExport:
       type: object
       required:
@@ -215,8 +222,7 @@ components:
         datasetNbn:
           type: string
         bagId:
-          type: string
-          x-field-extra-annotation: "@nl.knaw.dans.validation.UrnUuid"
+          $ref: '#/components/schemas/BagId'
         ocflObjectVersionNumber:
           type: integer
         createdTimestamp:
@@ -234,7 +240,7 @@ components:
         metadata:
           format: "json-ld"
           additionalProperties: true
-        filepidToLocalPath:
+        filePidToLocalPath:
           type: string
         deaccessioned:
           type: boolean


### PR DESCRIPTION
- Put SwordToken and UrnUuid in there own schemas
- Changed name of `filepidToLocalPath` to `filePidToLocalPath`
- Changed validation of SwordToken form urn:uuid to "sword:<uuid>".