### PR TITLE
DD-1580. Add FileMetas.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# configuration for authorized and required reviewers
+* @DANS-KNAW/core-systems-leads
+
+# code
+# no overrides
+
+# policies
+/.github/PULL_REQUEST_TEMPLATE.md @DANS-KNAW/core-systems-leads
+/.github/CODEOWNERS @DANS-KNAW/core-systems-leads

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+Fixes DD-
+
+# Description of changes
+
+# How to test
+
+# Related PRs
+
+(Add links)
+
+*
+
+# Notify
+
+@DANS-KNAW/core-systems

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </parent>
 
     <artifactId>dd-vault-catalog-api</artifactId>
-    <version>0.6.1-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
 
     <name>DD Vault Catalog API</name>
     <url>https://github.com/DANS-KNAW/dd-vault-catalog-api</url>

--- a/src/main/openapi/dd-vault-catalog-api.yml
+++ b/src/main/openapi/dd-vault-catalog-api.yml
@@ -206,6 +206,7 @@ components:
           type: string
         versionExports:
           type: array
+          default: []
           items:
             $ref: '#/components/schemas/VersionExport'
 
@@ -250,6 +251,7 @@ components:
           type: boolean
         fileMetas:
           type: array
+          default: []
           items:
             $ref: '#/components/schemas/FileMeta'
 

--- a/src/main/openapi/dd-vault-catalog-api.yml
+++ b/src/main/openapi/dd-vault-catalog-api.yml
@@ -238,8 +238,6 @@ components:
         metadata:
           format: "json-ld"
           additionalProperties: true
-        filePidToLocalPath:
-          type: string
         deaccessioned:
           type: boolean
         exporter:

--- a/src/main/openapi/dd-vault-catalog-api.yml
+++ b/src/main/openapi/dd-vault-catalog-api.yml
@@ -248,6 +248,25 @@ components:
           type: string
         skeletonRecord:
           type: boolean
+        fileMetas:
+          type: array
+          items:
+            $ref: '#/components/schemas/FileMeta'
 
-
-
+    FileMeta:
+      type: object
+      required:
+        - filepath
+        - fileUri
+        - sha1sum
+        - byteSize
+      properties:
+        filepath:
+          type: string
+        fileUri:
+          type: string
+          format: uri
+        sha1sum:
+          type: string
+        byteSize:
+          type: integer

--- a/src/main/openapi/dd-vault-catalog-api.yml
+++ b/src/main/openapi/dd-vault-catalog-api.yml
@@ -239,8 +239,7 @@ components:
         otherIdVersion:
           type: string
         metadata:
-          format: "json-ld"
-          additionalProperties: true
+          type: string
         deaccessioned:
           type: boolean
         exporter:
@@ -272,3 +271,4 @@ components:
           type: string
         byteSize:
           type: integer
+          format: int64

--- a/src/main/openapi/dd-vault-catalog-api.yml
+++ b/src/main/openapi/dd-vault-catalog-api.yml
@@ -229,6 +229,8 @@ components:
         archivedTimestamp:
           type: string
           format: date-time
+        title:
+          type: string
         dataversePidVersion:
           type: string
         otherId:


### PR DESCRIPTION
Fixes DD-1580

# Description of changes

* Added PR template and code owners.
* Adding the file metadata is the purpose of the is PR. 
* Also, made empty lists the default (rather than null values) for the DVEs and FileMetas fields.
* Change the type of the "metadata" (JSON-LD) field to a simple string. The structured format of the field was not used (anymore?) in the code.

# Notify

@DANS-KNAW/core-systems
