### PR TITLE
DD-1904 Added endpoint unconfirmedVersionExports

### DIFF
--- a/src/main/openapi/dd-vault-catalog-api.yml
+++ b/src/main/openapi/dd-vault-catalog-api.yml
@@ -334,6 +334,10 @@ components:
 
     UnconfirmedDatasetVersionExport:
       type: object
+      required:
+        - storageRoot
+        - datasetNbn
+        - ocflObjectVersionNumber
       properties:
         storageRoot:
           type: string

--- a/src/main/openapi/dd-vault-catalog-api.yml
+++ b/src/main/openapi/dd-vault-catalog-api.yml
@@ -169,6 +169,36 @@ paths:
         400:
           description: invalid input, object invalid
 
+  /dataset/{nbn}/versionExports/{ocflObjectVersionNumber}/archivedTimestamp:
+    put:
+      operationId: setVersionExportArchivedTimestamp
+      parameters:
+        - name: nbn
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: ocflObjectVersionNumber
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+              format: date-time
+      responses:
+        200:
+          description: archivedTimestamp updated
+        400:
+          description: invalid input, object invalid
+        404:
+          description: dataset or version export not found
+        409:
+          description: version export already has an archivedTimestamp
+
   /datasetVersionExport/{bagId}:
     get:
       operationId: getDatasetVersionExportByBagId
@@ -188,11 +218,11 @@ paths:
         404:
           description: dataset version export not found
 
-  /unconfirmedVersionExports:
+  /datasetVersionExport/unconfirmed:
     get:
       summary: Get unconfirmed Dataset Version Exports
       description: Returns Dataset Version Exports with no archivedTimestamp set.
-      operationId: getUnconfirmedVersionExports
+      operationId: getUnconfirmedDatasetVersionExports
       parameters:
         - name: limit
           in: query
@@ -253,7 +283,7 @@ components:
           type: string
         versionExports:
           type: array
-          default: []
+          default: [ ]
           items:
             $ref: '#/components/schemas/VersionExport'
 
@@ -297,7 +327,7 @@ components:
           type: boolean
         fileMetas:
           type: array
-          default: []
+          default: [ ]
           items:
             $ref: '#/components/schemas/FileMeta'
 

--- a/src/main/openapi/dd-vault-catalog-api.yml
+++ b/src/main/openapi/dd-vault-catalog-api.yml
@@ -188,6 +188,34 @@ paths:
         404:
           description: dataset version export not found
 
+  /unconfirmedVersionExports:
+    get:
+      summary: Get unconfirmed Dataset Version Exports
+      description: Returns Dataset Version Exports with no archivedTimestamp set.
+      operationId: getUnconfirmedVersionExports
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 100
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 0
+      responses:
+        200:
+          description: List of unconfirmed Dataset Version Exports
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/VersionExport'
+
 components:
 
   schemas:

--- a/src/main/openapi/dd-vault-catalog-api.yml
+++ b/src/main/openapi/dd-vault-catalog-api.yml
@@ -218,7 +218,7 @@ paths:
         404:
           description: dataset version export not found
 
-  /datasetVersionExport/unconfirmed:
+  /unconfirmedDatasetVersionExports:
     get:
       summary: Get unconfirmed Dataset Version Exports
       description: Returns Dataset Version Exports with no archivedTimestamp set.
@@ -244,7 +244,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/VersionExport'
+                  $ref: '#/components/schemas/UnconfirmedDatasetVersionExport'
 
 components:
 
@@ -330,6 +330,17 @@ components:
           default: [ ]
           items:
             $ref: '#/components/schemas/FileMeta'
+
+
+    UnconfirmedDatasetVersionExport:
+      type: object
+      properties:
+        storageRoot:
+          type: string
+        datasetNbn:
+          type: string
+        ocflObjectVersionNumber:
+          type: integer
 
     FileMeta:
       type: object


### PR DESCRIPTION
Fixes DD-1904

# Description of changes
* Added `/dataset/{nbn}/versionExports/{ocflObjectVersionNumber}/archivedTimestamp` to enable a client to set the archivedTimestamp of DVE.
* Added `/unconfirmedDatasetVersionExports` to enable a client to get the list of unconfirmed DVEs.

# Notify

@DANS-KNAW/core-systems
